### PR TITLE
added type-hint to eliminate reflection

### DIFF
--- a/dungeon-crawler/desktop/src-common/dungeon_crawler/utils.clj
+++ b/dungeon-crawler/desktop/src-common/dungeon_crawler/utils.clj
@@ -36,7 +36,7 @@
          nil?
          not)))
 
-(defn entity-rect
+(defn ^com.badlogic.gdx.math.Rectangle entity-rect
   [{:keys [x y x-feet y-feet width height]} min-distance]
   (rectangle (- (+ x x-feet)
                 (/ min-distance 4))


### PR DESCRIPTION
I noticed the fps for this demo was like
20-30 on my weak laptop, and I was curious
to see why it was so slow.  Turns out it
was the call to near-entity, which was
causing clojure to reflect on the args to
(rectangle! ....) which expect two instances
of gdx Rectangle objects.  I just plugged
in a typehint on entity-rect, and my fps
jumped to a solid 60 once the reflection
call was eliminated.  Easy fix.
